### PR TITLE
クラスファイルを適切なパッケージに移動

### DIFF
--- a/src/main/java/com/example/kadai9/controller/MovieController.java
+++ b/src/main/java/com/example/kadai9/controller/MovieController.java
@@ -1,5 +1,8 @@
-package com.example.kadai9;
+package com.example.kadai9.controller;
 
+import com.example.kadai9.entity.Movie;
+import com.example.kadai9.form.MovieForm;
+import com.example.kadai9.service.MovieService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/example/kadai9/entity/Movie.java
+++ b/src/main/java/com/example/kadai9/entity/Movie.java
@@ -1,4 +1,4 @@
-package com.example.kadai9;
+package com.example.kadai9.entity;
 
 import java.util.Objects;
 

--- a/src/main/java/com/example/kadai9/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/kadai9/exception/CustomExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.example.kadai9;
+package com.example.kadai9.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/kadai9/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/example/kadai9/exception/ResourceNotFoundException.java
@@ -1,4 +1,4 @@
-package com.example.kadai9;
+package com.example.kadai9.exception;
 
 public class ResourceNotFoundException extends RuntimeException{
     public ResourceNotFoundException(String message) {

--- a/src/main/java/com/example/kadai9/form/MovieForm.java
+++ b/src/main/java/com/example/kadai9/form/MovieForm.java
@@ -1,4 +1,4 @@
-package com.example.kadai9;
+package com.example.kadai9.form;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;

--- a/src/main/java/com/example/kadai9/mapper/MovieMapper.java
+++ b/src/main/java/com/example/kadai9/mapper/MovieMapper.java
@@ -1,5 +1,6 @@
-package com.example.kadai9;
+package com.example.kadai9.mapper;
 
+import com.example.kadai9.entity.Movie;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;

--- a/src/main/java/com/example/kadai9/service/MovieService.java
+++ b/src/main/java/com/example/kadai9/service/MovieService.java
@@ -1,4 +1,6 @@
-package com.example.kadai9;
+package com.example.kadai9.service;
+
+import com.example.kadai9.entity.Movie;
 
 import java.util.List;
 

--- a/src/main/java/com/example/kadai9/service/MovieServiceImpl.java
+++ b/src/main/java/com/example/kadai9/service/MovieServiceImpl.java
@@ -1,5 +1,8 @@
-package com.example.kadai9;
+package com.example.kadai9.service;
 
+import com.example.kadai9.entity.Movie;
+import com.example.kadai9.mapper.MovieMapper;
+import com.example.kadai9.exception.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,4 @@ spring.datasource.username=user
 spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 mybatis.configuration.map-underscore-to-camel-case=true
-mapper-locations=classpath*:com/example/kadai9/MovieMapper.xml
+mapper-locations=classpath*:com/example/kadai9/mapper/MovieMapper.xml

--- a/src/main/resources/com/example/kadai9/mapper/MovieMapper.xml
+++ b/src/main/resources/com/example/kadai9/mapper/MovieMapper.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.example.kadai9.MovieMapper">
-    <select id="findAll" resultType="com.example.kadai9.Movie">
+<mapper namespace="com.example.kadai9.mapper.MovieMapper">
+    <select id="findAll" resultType="com.example.kadai9.entity.Movie">
         SELECT * FROM movies
     </select>
-    <select id="findMovies" parameterType="int" resultType="com.example.kadai9.Movie">
+    <select id="findMovies" parameterType="int" resultType="com.example.kadai9.entity.Movie">
         SELECT * FROM movies WHERE published_year = #{publishedYear}
     </select>
-    <select id="findMovieById" parameterType="int" resultType="com.example.kadai9.Movie">
+    <select id="findMovieById" parameterType="int" resultType="com.example.kadai9.entity.Movie">
         SELECT * FROM movies WHERE id = #{id}
     </select>
-    <insert id="createMovie" parameterType="com.example.kadai9.Movie" useGeneratedKeys="true" keyProperty="id">
+    <insert id="createMovie" parameterType="com.example.kadai9.entity.Movie" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO movies (movie_title, published_year) VALUES (#{movieTitle}, #{publishedYear});
     </insert>
-    <update id="updateMovie" parameterType="com.example.kadai9.Movie">
+    <update id="updateMovie" parameterType="com.example.kadai9.entity.Movie">
         UPDATE movies SET movie_title = #{movieTitle}, published_year = #{publishedYear} Where id = #{id};
     </update>
     <delete id="deleteMovie" parameterType="int">

--- a/src/test/java/com/example/kadai9/controller/MovieControllerTest.java
+++ b/src/test/java/com/example/kadai9/controller/MovieControllerTest.java
@@ -1,8 +1,13 @@
-package com.example.kadai9;
+package com.example.kadai9.controller;
 
+import com.example.kadai9.entity.Movie;
+import com.example.kadai9.form.MovieForm;
+import com.example.kadai9.service.MovieServiceImpl;
+import com.example.kadai9.exception.ResourceNotFoundException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.ObjectWriter;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -195,7 +200,7 @@ class MovieControllerTest {
     public void 存在しないIDの映画を更新した際にResourceNotFoundExceptionを返すこと() throws Exception {
         int id = 1000; // 存在しないID
         MovieForm movieForm = new MovieForm("鋼の錬金術師 嘆きの丘の聖なる星", 2011);   // 画面からの入力値
-        doThrow(new ResourceNotFoundException("resource not found")).when(movieServiceImpl).updateMovie(id, movieForm.getMovieTitle(), movieForm.getPublishedYear());
+        Mockito.doThrow(new ResourceNotFoundException("resource not found")).when(movieServiceImpl).updateMovie(id, movieForm.getMovieTitle(), movieForm.getPublishedYear());
 
         // JSON形式のデータに変換
         ObjectWriter ow = new ObjectMapper().writer().withDefaultPrettyPrinter();

--- a/src/test/java/com/example/kadai9/integrationtest/MovieRestApiIntegrationTest.java
+++ b/src/test/java/com/example/kadai9/integrationtest/MovieRestApiIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.example.kadai9.integrationtest;
 
-import com.example.kadai9.MovieForm;
+import com.example.kadai9.form.MovieForm;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;

--- a/src/test/java/com/example/kadai9/mapper/MovieMapperTest.java
+++ b/src/test/java/com/example/kadai9/mapper/MovieMapperTest.java
@@ -1,5 +1,7 @@
-package com.example.kadai9;
+package com.example.kadai9.mapper;
 
+import com.example.kadai9.entity.Movie;
+import com.example.kadai9.mapper.MovieMapper;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;

--- a/src/test/java/com/example/kadai9/service/MovieServiceImplTest.java
+++ b/src/test/java/com/example/kadai9/service/MovieServiceImplTest.java
@@ -1,5 +1,8 @@
-package com.example.kadai9;
+package com.example.kadai9.service;
 
+import com.example.kadai9.entity.Movie;
+import com.example.kadai9.mapper.MovieMapper;
+import com.example.kadai9.exception.ResourceNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;


### PR DESCRIPTION
# 概要
コントローラー、サービス、マッパー、、エンティティ、フォームを適切なフォルダー配下に配置
main、test配下を移動しています。